### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -5,6 +5,9 @@
 
 name: Dart
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "**" ]


### PR DESCRIPTION
Potential fix for [https://github.com/discloud/discloud_config_dart/security/code-scanning/1](https://github.com/discloud/discloud_config_dart/security/code-scanning/1)

To address the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Since the workflow does not perform any write operations, we will set `contents: read` as the permission. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, adhering to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
